### PR TITLE
Add permissions for PHONE_STATE intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Just one of those permissions are needed, both access to a different level of information. E.g., android.permission.READ_CALL_LOG would broadcast the caller number and the android.permission.READ_PHONE_STATE would not.

This adds some level of refinement to the end-user.

Docs: https://developer.android.com/reference/android/telephony/TelephonyManager.html#ACTION_PHONE_STATE_CHANGED