### PR TITLE
Decrease MQTT rate for better real-time action/automations

### DIFF
--- a/app/src/main/java/pixento/nl/broadcasttomqtt/BroadcastItem.java
+++ b/app/src/main/java/pixento/nl/broadcasttomqtt/BroadcastItem.java
@@ -35,9 +35,9 @@ class BroadcastItem {
     
     /**
      * Defines the rate limit for the current broadcast. The number indicates the minimum time
-     * in seconds between MQTT messages. So 60s is once each minute.
+     * in seconds between MQTT messages. So 2s is once each minute.
      */
-    public int rate_limit = 60;
+    public int rate_limit = 2;
     
     /**
      * The latest sent payload, for debugging reasons


### PR DESCRIPTION
Reducing the 60s rate to 2s would improve response on MQTT messages for some time sensitive automations, on multiple and rapid broadcasts of the same intent.